### PR TITLE
Update to Node 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.0
+FROM node:18
 
 # AWS CLI needs the PYTHONIOENCODING environment variable to handle UTF-8 correctly:
 ENV PYTHONIOENCODING=UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14.18.0
 
 # AWS CLI needs the PYTHONIOENCODING environment variable to handle UTF-8 correctly:
 ENV PYTHONIOENCODING=UTF-8


### PR DESCRIPTION
Uses the 'oldest' available Docker Node image from https://hub.docker.com/_/node/ still above this current