### PR TITLE
Update Node from 14 to 16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18.0
+FROM node:18
 
 # AWS CLI needs the PYTHONIOENCODING environment variable to handle UTF-8 correctly:
 ENV PYTHONIOENCODING=UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:16
 
 # AWS CLI needs the PYTHONIOENCODING environment variable to handle UTF-8 correctly:
 ENV PYTHONIOENCODING=UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14
+FROM node:14.18.0
 
 # AWS CLI needs the PYTHONIOENCODING environment variable to handle UTF-8 correctly:
 ENV PYTHONIOENCODING=UTF-8


### PR DESCRIPTION
Uses the 'oldest' [available Docker Node image](https://hub.docker.com/_/node/) that's still above the current 14; 16 builds okay fine. 

Primarily needed for in this failing build (https://ci.services.comicrelief.com/teams/engineering/pipelines/spa-sorry/jobs/comicrelief-sorry-deploy/builds/32), which brings in some slightly updated deps via the new Storybook.

Will try this out as it's own tag to ensure it works fine in said context:

https://github.com/comicrelief/docker-node-sls-2/releases/tag/v2.0.0

https://hub.docker.com/layers/comicrelief/docker-node-sls-2/2.0.0/images/sha256-a647a091e1dc29f4b64892c16486f366820500f3152fd0296883858e91335f58?context=repo

